### PR TITLE
Huge rewrite

### DIFF
--- a/sublime-bogo.py
+++ b/sublime-bogo.py
@@ -2,38 +2,202 @@ import sys
 import sublime
 import sublime_plugin
 import os
+from itertools import takewhile
+import string
+
 sys.path.append(os.path.join(os.path.dirname(__file__), 'bogo/'))
 from bogo import core
 
 
-STATUS = True
-MODIFIED = False
+ENABLED = True
+LISTENER = None
+
+
+def only_if_enabled(function):
+    def inner(*args, **kwargs):
+        if ENABLED:
+            return function(*args, **kwargs)
+
+    return inner
 
 
 class BogoListener(sublime_plugin.EventListener):
-    def on_selection_modified(self, view):
-        global STATUS, MODIFIED
 
-        if not STATUS:
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        global LISTENER
+        self.other_command = False
+        self.editing_lock = False
+        LISTENER = self
+
+    # This gets called every time the cursor is moved and is where we detect
+    # user's key presses.
+    @only_if_enabled
+    def on_selection_modified(self, view):
+
+        if self.editing_lock:
             return
 
-        if not MODIFIED:
-            view.run_command('bogo')
+        # If a special command happens (left_delete, move,...),
+        # on_window_command and on_text_command is always called first.
+        # We don't care about special commands, just regular key presses.
+        if self.other_command:
+            self.other_command = False
+            return
 
-        MODIFIED = False
+        view = sublime.active_window().active_view()
+
+        # FIXME: Abstract this into a context manager?
+        self.editing_lock = True
+
+        # Find the char that has just been typed in
+        cursor = view.sel()[0]
+        if cursor.begin() == cursor.end():
+            cursor = sublime.Region(cursor.begin() - 1, cursor.end())
+            new_char = view.substr(cursor)
+
+            # Delete that new char
+            view.run_command('left_delete')
+
+            bogo_args = {
+                "command": "new_char",
+                "args": {
+                    "char": new_char
+                }
+            }
+            view.run_command('bogo', bogo_args)
+
+        self.editing_lock = False
+
+    @only_if_enabled
+    def on_window_command(self, window, command_name, args):
+        self.other_command = True
+
+    @only_if_enabled
+    def on_text_command(self, view, command_name, args):
+        """
+        Intercepts text commands before they actually run.
+
+        Return
+            None if we want to let the command run or a tuple of the form
+            ('command_name', {'args':'value'}) to specify a different command
+            to run instead of it.
+        """
+        self.other_command = True
+        self.new_text_command = None
+
+        self.editing_lock = True
+
+        if command_name == "left_delete":
+            view.run_command('bogo', {"command": command_name})
+        else:
+            view.run_command('bogo', {'command': 'reset'})
+
+        self.editing_lock = False
+        return self.new_text_command
+
+    # This will be called by the BogoCommand to determine whether we
+    # should swallow this text_command.
+    def on_text_command_callback(self, new_command):
+        self.new_text_command = new_command
 
 
 class BogoEnableToggleCommand(sublime_plugin.TextCommand):
     def run(self, edit):
-        global STATUS
-        if STATUS:
-            STATUS = False
+        global ENABLED
+        if ENABLED:
+            ENABLED = False
         else:
-            STATUS = True
-        self.view.set_status('BogoEnabled', str(STATUS))
+            ENABLED = True
+        self.view.set_status('BogoEnabled', str(ENABLED))
 
 
 class BogoCommand(sublime_plugin.TextCommand):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.reset()
+
+    def reset(self):
+        self.sequence = ""
+        self.previously_committed_string = ""
+
+    def accepted_chars(self):
+        if sys.version_info[0] > 2:
+            accepted_chars = \
+                string.ascii_letters + \
+                ''.join(self.getRule().keys())
+        else:
+            accepted_chars = \
+                string.lowercase + \
+                string.uppercase + \
+                ''.join(self.getRule().keys())
+
+        return accepted_chars
+
+    # Command dispatcher
+    def run(self, edit, command, args={}):
+        self.edit = edit
+
+        if command == "new_char":
+            self.on_new_char(args["char"])
+        elif command == "reset":
+            self.reset()
+        elif command == "left_delete":
+            self.on_left_delete()
+
+    def on_new_char(self, char):
+        if not char in self.accepted_chars():
+            self.view.insert(self.edit, self.view.sel()[0].begin(), char)
+            self.reset()
+        else:
+            if self.sequence == "":
+                # Try to continue from the existing string at the cursor
+                # position.
+                word_under_cursor = self.view.substr(
+                    self.view.word(self.view.sel()[0]))
+
+                if word_under_cursor.isalpha():
+                    self.sequence = word_under_cursor
+
+                self.previously_committed_string = self.sequence
+
+            self.sequence += char
+            result = core.process_sequence(self.sequence)
+            self.commit(result)
+
+    def on_left_delete(self):
+        self.sequence = self.sequence[:-1]
+        if self.sequence == "":
+            self.reset()
+        else:
+            result = core.process_sequence(self.sequence)
+            self.commit(result)
+
+            # NOTE blank_command is just a made up command. It doesn't exist
+            # (at least I think it doesn't) so ST will do nothing.
+            LISTENER.on_text_command_callback(("blank_command", {}))
+
+    def commit(self, string):
+        same_initial_chars = list(
+            takewhile(lambda tupl: tupl[0] == tupl[1],
+                      zip(self.previously_committed_string,
+                          string)))
+
+        chars_to_delete = len(
+            self.previously_committed_string) - len(same_initial_chars)
+
+        cursor = self.view.sel()[0]
+        replace_region = sublime.Region(
+            cursor.begin() - chars_to_delete, cursor.end())
+        replace_with = string[len(same_initial_chars):]
+
+        self.view.erase(self.edit, replace_region)
+        self.view.insert(self.edit, replace_region.begin(), replace_with)
+
+        self.previously_committed_string = string
+
     def getRule(self):
         """
         Get bogo rule definition from setting
@@ -49,7 +213,7 @@ class BogoCommand(sublime_plugin.TextCommand):
         """
         # cast setting to str, then in case users give a wrong input, it should
         # fallback to Telex rule
-        bogoRule =\
+        bogoRule = \
             str(sublime.load_settings('Bogo.sublime-settings')
                 .get('bogo-rule')).upper()
 
@@ -57,23 +221,3 @@ class BogoCommand(sublime_plugin.TextCommand):
             return core.get_vni_definition()
         else:
             return core.get_telex_definition()
-
-    # Text command which replace Vietnamese
-    def run(self, edit):
-        global MODIFIED
-        selections = self.view.sel()
-
-        if not selections:
-            return
-
-        # Get current word
-        for selection in selections:
-            region = self.view.word(selection)
-            st = self.view.substr(region)
-
-            if len(st) > 0:
-                replace = core.process_sequence(st, self.getRule())
-                # Ok, it's a Vietnamese input
-                if replace != st:
-                    self.view.replace(edit, region, replace)
-                    MODIFIED = True

--- a/sublime-bogo.py
+++ b/sublime-bogo.py
@@ -171,6 +171,9 @@ class BogoCommand(sublime_plugin.TextCommand):
             self.commit(result)
 
     def on_left_delete(self):
+        # NOTE: We are not deleting from the text on the screen but from
+        # the raw key sequence. As such, the backspace key doubles as
+        # an undo key. This may be confusing for some users.
         self.sequence = self.sequence[:-1]
         if self.sequence == "":
             self.reset()
@@ -178,8 +181,9 @@ class BogoCommand(sublime_plugin.TextCommand):
             result = core.process_sequence(self.sequence)
             self.commit(result)
 
-            # NOTE blank_command is just a made up command. It doesn't exist
+            # NOTE: blank_command is just a made up command. It doesn't exist
             # (at least I think it doesn't) so ST will do nothing.
+            # Therfore, we effectively swallow the backspace key.
             LISTENER.on_text_command_callback(("blank_command", {}))
 
     def commit(self, string):

--- a/sublime-bogo.py
+++ b/sublime-bogo.py
@@ -21,6 +21,22 @@ def only_if_enabled(function):
     return inner
 
 
+def update_status_line():
+    for window in sublime.windows():
+        for view in window.views():
+            view.set_status('bogo.enabled', 'BoGo: ' + ('OFF', 'ON')[ENABLED])
+
+
+def plugin_loaded():
+    update_status_line()
+
+
+def plugin_unloaded():
+    for window in sublime.windows():
+        for view in window.views():
+            view.erase_status('bogo.enabled')
+
+
 class BogoListener(sublime_plugin.EventListener):
 
     def __init__(self, *args, **kwargs):
@@ -69,10 +85,12 @@ class BogoListener(sublime_plugin.EventListener):
             view.run_command('bogo', bogo_args)
 
         self.editing_lock = False
+        update_status_line()
 
     @only_if_enabled
     def on_window_command(self, window, command_name, args):
         self.other_command = True
+        update_status_line()
 
     @only_if_enabled
     def on_text_command(self, view, command_name, args):
@@ -95,6 +113,7 @@ class BogoListener(sublime_plugin.EventListener):
             view.run_command('bogo', {'command': 'reset'})
 
         self.editing_lock = False
+        update_status_line()
         return self.new_text_command
 
     # This will be called by the BogoCommand to determine whether we
@@ -110,7 +129,8 @@ class BogoEnableToggleCommand(sublime_plugin.TextCommand):
             ENABLED = False
         else:
             ENABLED = True
-        self.view.set_status('BogoEnabled', str(ENABLED))
+
+        update_status_line()
 
 
 class BogoCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
We now detect the key press (in `BogoListener.on_selection_modified`) and maintain a sequence of raw key presses (`BogoCommand.sequence`).

Should fix: #3, #6, #11.
