### PR TITLE
Support undoing previous words with backspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,8 @@ Some functions from `bogo.core` are exported to package toplevel:
 - `get_vni_definition()`
 
 BoGo is extensively tested with Python 2.7, Python 3.2 and Python 3.3.
+
+Etymology
+---------
+
+BoGo, or more precisely *bộ gõ*, literally means *input method* in Vietnamese.

--- a/bogo/test/test_engine.py
+++ b/bogo/test/test_engine.py
@@ -184,3 +184,8 @@ class TestProcessSeq():
         # eq_(process_sequence("aans.tuongwj"), "ấn.tượng")
         eq_(process_sequence("gi[f"), "giờ")
         # eq_(process_sequence("taojc"), "taojc")
+
+    def test_with_separator(self):
+        eq_(process_sequence('con meof dideen'), 'con mèo điên')
+        eq_(process_sequence('con.meof'), 'con.mèo')
+        eq_(process_sequence('con?meof'), 'con?mèo')

--- a/sublime-bogo.py
+++ b/sublime-bogo.py
@@ -3,7 +3,6 @@ import sublime
 import sublime_plugin
 import os
 from itertools import takewhile
-import string
 
 sys.path.append(os.path.join(os.path.dirname(__file__), 'bogo/'))
 from bogo import core
@@ -129,19 +128,6 @@ class BogoCommand(sublime_plugin.TextCommand):
         self.sequence = ""
         self.previously_committed_string = ""
 
-    def accepted_chars(self):
-        if sys.version_info[0] > 2:
-            accepted_chars = \
-                string.ascii_letters + \
-                ''.join(self.getRule().keys())
-        else:
-            accepted_chars = \
-                string.lowercase + \
-                string.uppercase + \
-                ''.join(self.getRule().keys())
-
-        return accepted_chars
-
     # Command dispatcher
     def run(self, edit, command, args={}):
         self.edit = edit
@@ -154,27 +140,22 @@ class BogoCommand(sublime_plugin.TextCommand):
             self.on_left_delete()
 
     def on_new_char(self, char):
-        if char not in self.accepted_chars():
-            self.reset()
-            self.commit(char)
-            self.reset()
-        else:
-            if self.sequence == "" and len(self.view.sel()) == 1:
-                # Try to continue from the existing string at the cursor
-                # position only if there is only one cursor.
-                # Things would get weird if there are several cursors
-                # with different words under each.
-                word_under_cursor = self.view.substr(
-                    self.view.word(self.view.sel()[0]))
+        if self.sequence == "" and len(self.view.sel()) == 1:
+            # Try to continue from the existing string at the cursor
+            # position only if there is only one cursor.
+            # Things would get weird if there are several cursors
+            # with different words under each.
+            word_under_cursor = self.view.substr(
+                self.view.word(self.view.sel()[0]))
 
-                if word_under_cursor.isalpha():
-                    self.sequence = word_under_cursor
+            if word_under_cursor.isalpha():
+                self.sequence = word_under_cursor
 
-                self.previously_committed_string = self.sequence
+            self.previously_committed_string = self.sequence
 
-            self.sequence += char
-            result = core.process_sequence(self.sequence)
-            self.commit(result)
+        self.sequence += char
+        result = core.process_sequence(self.sequence)
+        self.commit(result)
 
     def on_left_delete(self):
         # NOTE: We are not deleting from the text on the screen but from


### PR DESCRIPTION
Now that process_sequence() has acquired support for separators, we don't need to reset() on unaccepted chars. We just keep them in the raw sequence and the committed string. So they can get pretty long like this: 
- stored key sequence = 'con meof ddieen'
- committed string = 'con mèo điên'

As such, it is now even possible to undo the grave tone in mèo. To test, type in 'con meof ddieen' and repeatedly press backspace so that the cursor is right after mèo. Press backspace one more time, you can see that the grave tone is undone and we have 'meo'.
