### PR TITLE
Create keyboard binding for backspace

### DIFF
--- a/Default.sublime-keymap
+++ b/Default.sublime-keymap
@@ -8,7 +8,7 @@
     // {"keys": ["end"], "command": "bogo_key", "args": {"key": "end"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
     // {"keys": ["pageup"], "command": "bogo_key", "args": {"key": "pageup"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
     // {"keys": ["pagedown"], "command": "bogo_key", "args": {"key": "pagedown"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
-    // {"keys": ["backspace"], "command": "bogo_key", "args": {"key": "backspace"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
+    {"keys": ["backspace"], "command": "bogo_key", "args": {"key": "backspace"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
     // {"keys": ["delete"], "command": "bogo_key", "args": {"key": "delete"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
     // {"keys": ["tab"], "command": "bogo_key", "args": {"key": "tab"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},
     // {"keys": ["enter"], "command": "bogo_key", "args": {"key": "enter"}, "context": [{"key": "setting.bogo.enabled", "operator": "equal", "operand": true}, {"key": "setting.command_mode", "operand": false}]},


### PR DESCRIPTION
Before, we handle backspace by intercepting the "left_delete" command with the on_text_command event. But on_text_command is not available on ST2 so we have to bind directly to backspace just like any other characters.

Should fix #24.
