### PR TITLE
Better backspace

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,7 @@
+Workflow for releasing a new version:
+
+1. Update the version in `setup.py` (even the `download_url`). Commit it with message "Bump version to x.x.x"
+2. Tag the new commit as vx.x.x (v1.1, v1.0.1)
+3. Push to Github
+4. Update the releases page: https://github.com/BoGoEngine/bogo-python/releases
+5. Upload to PyPI: https://docs.python.org/2/distutils/packageindex.html#package-index

--- a/bogo/bogo/__init__.py
+++ b/bogo/bogo/__init__.py
@@ -28,4 +28,5 @@ from bogo.core import \
     process_key, \
     process_sequence, \
     get_telex_definition, \
-    get_vni_definition
+    get_vni_definition, \
+    handle_backspace

--- a/bogo/bogo/core.py
+++ b/bogo/bogo/core.py
@@ -487,3 +487,35 @@ def _can_undo(comps, trans_list):
                     accent.remove_accent_char(comps[1][-1]))  # ơ, ư
 
     return any(map(atomic_check, action_list))
+
+
+def handle_backspace(converted_string, raw_sequence):
+    """
+    Returns a new converted_string and a new raw_sequence
+    after a backspace.
+    """
+    # I can't find a simple explanation for this, so
+    # I hope this example can help clarify it:
+    #
+    # handle_backspace(thương, thuwongw) -> (thươn, thuwonw)
+    # handle_backspace(thươn, thuwonw) -> (thươ, thuwow)
+    # handle_backspace(thươ, thuwow) -> (thư, thuw)
+    # handle_backspace(thươ, thuw) -> (th, th)
+    #
+    # The algorithm for handle_backspace was contributed by @hainp.
+
+    deleted_char = converted_string[-1]
+    converted_string = converted_string[:-1]
+
+    _accent = accent.get_accent_char(deleted_char)
+    _mark = mark.get_mark_char(deleted_char)
+
+    if _mark and _accent:
+        raw_sequence = raw_sequence[:-3]
+    elif _mark or _accent:
+        raw_sequence = raw_sequence[:-2]
+    else:
+        index = raw_sequence.rfind(deleted_char)
+        raw_sequence = raw_sequence[:index] + raw_sequence[(index + 1):]
+
+    return converted_string, raw_sequence

--- a/bogo/bogo/test/test_engine.py
+++ b/bogo/bogo/test/test_engine.py
@@ -6,7 +6,7 @@ from nose.plugins.attrib import attr
 from functools import partial
 import codecs
 
-from bogo.core import _Action, _get_action, process_sequence
+from bogo.core import _Action, _get_action, process_sequence, handle_backspace
 from bogo.mark import Mark
 import os
 
@@ -193,3 +193,20 @@ class TestProcessSeq():
     def test_change_tone(self):
         eq_(process_sequence('meofs'), 'méo')
         eq_(process_sequence('mèos'), 'méo')
+
+
+class TestHandleBackspace():
+
+	def test_delete_non_im_key(self):
+		eq_(handle_backspace('an', 'an'), ('a', 'a'))
+		eq_(handle_backspace('a', 'a'), ('', ''))
+
+	def test_delete_one_im_key(self):
+		eq_(handle_backspace('bà', 'baf'), ('b', 'b'))
+		eq_(handle_backspace('bâ', 'baa'), ('b', 'b'))
+
+	def test_delete_two_im_keys(self):
+		eq_(handle_backspace('bớ', 'bows'), ('b', 'b'))
+	
+	def test_non_im_key_before_im_key(self):
+		eq_(handle_backspace('bân', 'bana'), ('bâ', 'baa'))

--- a/bogo/setup.py
+++ b/bogo/setup.py
@@ -5,12 +5,12 @@ from distutils.core import setup
 setup(
     name='bogo',
     packages=['bogo'],
-    version='1.0.1',
+    version='1.1',
     description='Library for implementing Vietnamese input method editors with a purely functional interface.',
     author='Trung Ngo',
     author_email='ndtrung4419@gmail.com',
     url='https://github.com/BoGoEngine/bogo-python',
-    download_url='https://github.com/BoGoEngine/bogo-python/archive/v1.0.tar.gz',
+    download_url='https://github.com/BoGoEngine/bogo-python/archive/v1.1.tar.gz',
     keywords=['vietnamese'],
     classifiers=[
         "Programming Language :: Python",

--- a/sublime-bogo.py
+++ b/sublime-bogo.py
@@ -119,16 +119,15 @@ class BogoCommand(sublime_plugin.TextCommand):
         self.commit(result)
 
     def on_left_delete(self):
-        # NOTE: We are not deleting from the text on the screen but from
-        # the raw key sequence. As such, the backspace key doubles as
-        # an undo key. This may be confusing for some users.
-        self.sequence = self.sequence[:-1]
         if self.sequence == "":
             self.reset()
             self.view.run_command('left_delete')
         else:
-            result = core.process_sequence(self.sequence)
-            self.commit(result)
+            new_converted_string, self.sequence = \
+                core.handle_backspace(
+                    self.previously_committed_string,self.sequence)
+
+            self.commit(new_converted_string)
 
     def commit(self, string):
         same_initial_chars = list(


### PR DESCRIPTION
Before this PR, backspace means undo so typing backspace with "à" gives "a". Now a backspace is a backspace.
